### PR TITLE
Replace yum with generic package manager

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 - name: install satyr packages
-  yum: pkg={{ item }} state=latest
+  package: name={{ item }} state=latest
   become: true
   with_items: "{{ satyr_packages }}"
 
 - name: install libreport packages
-  yum: pkg={{ item }} state=latest
+  package: name={{ item }} state=latest
   become: true
   with_items: "{{ libreport_packages }}"
 
 - name: install abrt packages
-  yum: pkg={{ item }} state=latest
+  package: name={{ item }} state=latest
   become: true
   with_items: "{{ abrt_packages }}"
 


### PR DESCRIPTION
Generic package manager - package, is able to install packages on all
major package managers, including yum, dnf or apt.