### PR TITLE
Fix missing python bindings for selinux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: install python libselinux package
+  package: name=python3-libselinux state=latest
+  become: true
+  when: ansible_selinux is defined and ansible_selinux.status == 'enabled'
+
 - name: install satyr packages
   package: name={{ item }} state=latest
   become: true


### PR DESCRIPTION
Caused by 9adac40a3f0a9d3be4e30cbfbf7e3d6989566abb

To make any kind of file operations on SELinux enabled node pythonX-libselinux needs to be
installed there.

https://docs.ansible.com/ansible/latest/intro_installation.html#managed-node-requirements

Signed-off-by: Martin Kutlak <mkutlak@redhat.com>